### PR TITLE
Require Go 1.9.x for development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-   - 1.8
+   - 1.9
    - master
 before_script:
    - cp bin/run-test{.travis,}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SOURCE_FILES?=$$(go list ./... | grep -v '/deloominator/vendor/')
+SOURCE_FILES?=$$(go list ./...)
 TEST_PATTERN?=.
 TEST_OPTIONS?=
 

--- a/docs/developers-manual.md
+++ b/docs/developers-manual.md
@@ -19,7 +19,7 @@ list of prerequisites to build and test the project:
 
 - Build:
   - `make`
-  - [Go 1.8+](http://golang.org/doc/install)
+  - [Go 1.9+](http://golang.org/doc/install)
   - [Node.js](https://nodejs.org/en/)
   - [Yarn](https://yarnpkg.com/en/)
 - Test:
@@ -141,13 +141,13 @@ is a technique to handle fixture files used in assertion. It works this way:
 - You store complex output you expect (like a JSON response for example) in a
   file and use it to compare it to the actual outcome of a test
 - You add a command line flag that updates your golden file so that it is easy
-  to get a test passing when behaviour changes
+  to get a test passing when behavior changes
 
 You can find an example of it [here](/pkg/api/graphql_test.go).
 
 ### Use testutil
 
-The [testutil](pkg/testutil) package contains a number of utitilies for testing
+The [testutil](pkg/testutil) package contains a number of utilities for testing
 our Go code. In the spirit of [Advanced testing with
 Go](https://speakerdeck.com/mitchellh/advanced-testing-with-go), we follow these
 guidelines:

--- a/pkg/testutil/test_file.go
+++ b/pkg/testutil/test_file.go
@@ -20,11 +20,13 @@ type TestFile struct {
 
 // NewFixture returns a TestFile from a given fixture
 func NewFixture(t *testing.T, fixture string) *TestFile {
+	t.Helper()
 	return &TestFile{t: t, name: fixture, dir: "fixtures"}
 }
 
 // NewGoldenFile returns a TestFile from a given golden name file
 func NewGoldenFile(t *testing.T, name string) *TestFile {
+	t.Helper()
 	return &TestFile{t: t, name: name, dir: "golden"}
 }
 
@@ -46,6 +48,7 @@ func (tf *TestFile) Write(content string) {
 
 // Load returns the content of a TestFile
 func (tf *TestFile) Load() string {
+	tf.t.Helper()
 	content, err := ioutil.ReadFile(tf.path())
 	if err != nil {
 		tf.t.Fatalf("could not read file %s: %v", tf.name, err)
@@ -56,6 +59,7 @@ func (tf *TestFile) Load() string {
 
 // Parse parses the content of a TestFile
 func (tf *TestFile) Parse(w io.Writer, data string) {
+	tf.t.Helper()
 	tmpl := template.Must(template.New(tf.name).Parse(tf.Load()))
 
 	err := tmpl.Execute(w, data)
@@ -65,6 +69,7 @@ func (tf *TestFile) Parse(w io.Writer, data string) {
 }
 
 func (tf *TestFile) ParseOrUpdate(update bool, data, actual string) string {
+	tf.t.Helper()
 	out := &bytes.Buffer{}
 
 	tf.Parse(out, data)

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -140,6 +140,7 @@ func setupMySQL(t *testing.T) (string, func()) {
 }
 
 func LoadDataFromFixture(t *testing.T, ds *db.DataSource, fixture string) {
+	t.Helper()
 	query := NewFixture(t, fixture).Load()
 
 	if _, err := ds.Exec(query); err != nil {
@@ -148,6 +149,7 @@ func LoadDataFromFixture(t *testing.T, ds *db.DataSource, fixture string) {
 }
 
 func LoadData(t *testing.T, ds *db.DataSource, table string, data db.QueryResult) {
+	t.Helper()
 	query := &bytes.Buffer{}
 
 	columns := make([]string, len(data.Columns))
@@ -181,6 +183,7 @@ func LoadData(t *testing.T, ds *db.DataSource, table string, data db.QueryResult
 }
 
 func CreateDSN(t *testing.T) []string {
+	t.Helper()
 	cfg, err := getTestConfig()
 	if err != nil {
 		t.Fatalf("could not get test config: %v", err)
@@ -189,6 +192,7 @@ func CreateDSN(t *testing.T) []string {
 }
 
 func NewStorage(t *testing.T, source string) *storage.Storage {
+	t.Helper()
 	s, err := storage.NewStorage(source)
 	if err != nil {
 		t.Fatalf("could not create storage: %v", err)
@@ -201,6 +205,7 @@ func NewStorage(t *testing.T, source string) *storage.Storage {
 }
 
 func NewStorages(t *testing.T) (storages []*storage.Storage) {
+	t.Helper()
 	sources := CreateDSN(t)
 
 	for _, dsn := range sources {
@@ -211,6 +216,7 @@ func NewStorages(t *testing.T) (storages []*storage.Storage) {
 }
 
 func CreateDataSources(t *testing.T) ([]string, func()) {
+	t.Helper()
 	cfg, err := getTestConfig()
 	if err != nil {
 		t.Fatalf("could not get test config: %v", err)
@@ -225,6 +231,7 @@ func CreateDataSources(t *testing.T) ([]string, func()) {
 }
 
 func SetupDataSources(t *testing.T) (db.DataSources, func()) {
+	t.Helper()
 	dsnPG, cleanupPG := setupPG(t)
 	dsnMySQL, cleanupMySQL := setupMySQL(t)
 


### PR DESCRIPTION
Go 1.9 introduced t.Helper() and changed the behaviour of `go test ./...`. Both features are helpful and I feel it's good to push for using latest Go version if possible